### PR TITLE
unity2019导出了Baselib，用到了System.UIntPtr类型对应c++的size_t

### DIFF
--- a/BindGenerater/Generater/C/CTypeResolver.cs
+++ b/BindGenerater/Generater/C/CTypeResolver.cs
@@ -102,6 +102,8 @@ namespace Generater.C
                     return "uint8_t";
                 case "SByte":
                     return "int8_t";
+                case "UIntPtr":
+                    return "size_t";
             }
 
             return type.Name;


### PR DESCRIPTION
让生成的 icall_binding_gen.c 代码可以将 unity2019 里面导出的 Baselib 用到的 System.UIntPtr 转为 c 中的 size_t